### PR TITLE
Add some missing constructs to Bangla

### DIFF
--- a/languages.csv
+++ b/languages.csv
@@ -2,7 +2,7 @@ Code,Name,Directory,Functor,Unlexer,Present,All,Try,Symbolic,Compatibility,Synop
 Afr,Afrikaans,afrikaans,,,,,,n,,y
 Amh,Amharic,amharic,,,,,n,n,,n
 Ara,Arabic,arabic,,,,,,y,,y
-Ben,Bangla,bangla,n,n,n,y,n,n,n,n
+Ben,Bangla,bangla,,,y,,,,,y
 Bul,Bulgarian,bulgarian,,,y,,,,,y
 Cat,Catalan,catalan,Romance,,y,,,,y,y
 Cgg,Rukiga,rukiga,,,y,y,n,n,y,y

--- a/src/api/SymbolicBen.gf
+++ b/src/api/SymbolicBen.gf
@@ -1,0 +1,6 @@
+--# -path=.:../bangla:../common:../abstract:../prelude
+
+resource SymbolicBen = Symbolic with
+  (Symbol = SymbolBen),
+  (Grammar = GrammarBen)
+  ** open MissingBen in {} ;

--- a/src/api/TryBen.gf
+++ b/src/api/TryBen.gf
@@ -1,21 +1,21 @@
 --# -path=.:../bangla:../common:../abstract:../prelude
 
-resource TryBen = SyntaxBen-[mkAdN], LexiconBen, ParadigmsBen - [mkAdv,mkAdN,mkOrd,mkQuant,mkVoc, Prep] **
+resource TryBen = Prelude, SyntaxBen-[mkAdN], LexiconBen, ParadigmsBen - [mkAdv,mkAdN,mkOrd,mkQuant,mkVoc, Prep] **
   open (P = ParadigmsBen) in {
 
 oper
 
   mkAdv = overload SyntaxBen {
-    mkAdv : Str -> Adv = P.mkAdv ;
+    mkAdv : Str -> Adv = \s -> lin Adv (ss s) ;
   } ;
 
   mkAdN = overload {
     mkAdN : CAdv -> AdN = SyntaxBen.mkAdN ;
-    mkAdN : Str -> AdN = P.mkAdN ;
+    mkAdN : Str -> AdN =  \s -> lin AdN (ss s)  ;
   } ;
 
   mkOrd = overload SyntaxBen {
-    mkOrd : Str -> Ord = P.mkOrd ;
+    mkOrd : Str -> Ord =  \s -> lin Ord (ss s)  ;
   } ;
 
 

--- a/src/bangla/MissingBen.gf
+++ b/src/bangla/MissingBen.gf
@@ -2,15 +2,11 @@ resource MissingBen = open GrammarBen, SymbolBen, Prelude in {
 -- temporary definitions to enable the compilation of RGL API
 oper AdAP : AdA -> AP -> AP  = notYet "AdAP" ;
 oper CNSymbNP : Det -> CN -> [Symb] -> NP = notYet "CNSymbNP" ;
--- oper SymbPN : Symb -> PN = notYet "SymbPN" ;
--- oper IntPN : Int -> PN = notYet "IntPN" ;
--- oper FloatPN : Float -> PN = notYet "FloatPN" ;
 oper NumPN : Card -> PN = notYet "NumPN" ;
 oper CNNumNP : CN -> Card -> NP = notYet "CNNumNP" ;
 oper SymbS : Symb -> S = notYet "SymbS" ;
 oper SymbNum : Symb -> Card = notYet "SymbNum" ;
 oper SymbOrd : Symb -> Ord = notYet "SymbOrd" ;
--- oper Symb : Str -> NP = notYet "Symb" ;
 oper AdAdv : AdA -> Adv -> Adv  = notYet "AdAdv" ;
 oper AdNum : AdN -> Card -> Card  = notYet "AdNum" ;
 oper AdVVP : AdV -> VP -> VP  = notYet "AdVVP" ;

--- a/src/bangla/NounBen.gf
+++ b/src/bangla/NounBen.gf
@@ -126,9 +126,12 @@ concrete NounBen of Noun = CatBen ** open ResBen, Prelude in {
   -- : Quant
   -- Definite and Indefinite article does not exist as a word in Bangla, rather it exists as 
   -- a property of the Noun
-  
-  -- DefArt = mkQuant "the" "the" ;
-  -- IndefArt = mkQuant "a" [] ;
+
+  DefArt = ss "" ;
+  IndefArt = ss "" ;
+  -- Inari: eventually change the lincat of Quant, and
+  -- have these include a param that determines whether
+  -- to choose Indefinite or Definite from the inflection table of the N
 
 {-
   -- : Pron -> Quant        -- my

--- a/src/bangla/ParadigmsBen.gf
+++ b/src/bangla/ParadigmsBen.gf
@@ -192,6 +192,10 @@ oper
   mkPrep = overload {
     mkPrep : Str -> Case -> Prep = \s, c -> lin Prep {s = s ; c = c} ;
     } ;
+
+  mkAdv = overload {
+    mkAdv : Str -> Adv = \s -> lin Adv (ss s) ;
+    } ;
 {-
   mkConj = overload {
     mkConj : (and : Str) -> Conj = \s -> …

--- a/src/bangla/SymbolBen.gf
+++ b/src/bangla/SymbolBen.gf
@@ -51,7 +51,7 @@ oper
     --   } ;
 
 mkPN_onRuntimeToken : Str -> LinPN = \str -> {
-  s = table { 
+  s = table {
     NPBare => str ;
     NPC Gen => str ++ "এর" ;
     NPC _ => str
@@ -65,8 +65,8 @@ lincat
 lin
   MkSymb s = s ;
 
---   BaseSymb = infixSS "and" ; -- this comes between the last two ones
---   ConsSymb = infixSS "," ;
+  BaseSymb = infixSS "এবং" ; -- this comes between the last two ones
+  ConsSymb = infixSS "," ;
 
 
 }

--- a/src/chinese/ParadigmsChi.gf
+++ b/src/chinese/ParadigmsChi.gf
@@ -155,6 +155,8 @@ oper
       = \s,at -> lin Adv {s = word s ; advType = at ; hasDe = advTypeHasDe at} ;
     mkAdv : Adv -> AdvType -> Adv -- To fix the AdvType in an Adv produced by SyntaxChi.mkAdv
       = \adv,at -> adv ** {advType = at ; hasDe = advTypeHasDe at} ;
+    mkAdv : Str -> AdvType -> Bool -> Adv
+      = \s,at,hasDe -> lin Adv {s = word s ; advType = at ; hasDe = hasDe} ;
 
     } ;
 

--- a/src/romanian/DocumentationRon.gf
+++ b/src/romanian/DocumentationRon.gf
@@ -12,51 +12,48 @@ lin InflectionA, InflectionA2 = \x -> {
       s1="" ;
       s2=frameTable (
            tr (intagAttr "th" "rowspan=\"25\"" "s" ++ th "AF Masc Sg Indef ANomAcc" ++ td (x.s ! AF Masc Sg Indef ANomAcc)) ++
-           tr (th "AF Masc Sg Indef AGenDat" ++ td (x.s ! AF Masc Sg Indef AGenDat)) ++
-           tr (th "AF Masc Sg Indef AVoc" ++ td (x.s ! AF Masc Sg Indef AVoc)) ++
-           tr (th "AF Masc Sg Def ANomAcc" ++ td (x.s ! AF Masc Sg Def ANomAcc)) ++
-           tr (th "AF Masc Sg Def AGenDat" ++ td (x.s ! AF Masc Sg Def AGenDat)) ++
-           tr (th "AF Masc Sg Def AVoc" ++ td (x.s ! AF Masc Sg Def AVoc)) ++
-           tr (th "AF Masc Pl Indef ANomAcc" ++ td (x.s ! AF Masc Pl Indef ANomAcc)) ++
-           tr (th "AF Masc Pl Indef AGenDat" ++ td (x.s ! AF Masc Pl Indef AGenDat)) ++
-           tr (th "AF Masc Pl Indef AVoc" ++ td (x.s ! AF Masc Pl Indef AVoc)) ++
-           tr (th "AF Masc Pl Def ANomAcc" ++ td (x.s ! AF Masc Pl Def ANomAcc)) ++
-           tr (th "AF Masc Pl Def AGenDat" ++ td (x.s ! AF Masc Pl Def AGenDat)) ++
-           tr (th "AF Masc Pl Def AVoc" ++ td (x.s ! AF Masc Pl Def AVoc)) ++
-           tr (th "AF Fem Sg Indef ANomAcc" ++ td (x.s ! AF Fem Sg Indef ANomAcc)) ++
-           tr (th "AF Fem Sg Indef AGenDat" ++ td (x.s ! AF Fem Sg Indef AGenDat)) ++
-           tr (th "AF Fem Sg Indef AVoc" ++ td (x.s ! AF Fem Sg Indef AVoc)) ++
-           tr (th "AF Fem Sg Def ANomAcc" ++ td (x.s ! AF Fem Sg Def ANomAcc)) ++
-           tr (th "AF Fem Sg Def AGenDat" ++ td (x.s ! AF Fem Sg Def AGenDat)) ++
-           tr (th "AF Fem Sg Def AVoc" ++ td (x.s ! AF Fem Sg Def AVoc)) ++
-           tr (th "AF Fem Pl Indef ANomAcc" ++ td (x.s ! AF Fem Pl Indef ANomAcc)) ++
-           tr (th "AF Fem Pl Indef AGenDat" ++ td (x.s ! AF Fem Pl Indef AGenDat)) ++
-           tr (th "AF Fem Pl Indef AVoc" ++ td (x.s ! AF Fem Pl Indef AVoc)) ++
-           tr (th "AF Fem Pl Def ANomAcc" ++ td (x.s ! AF Fem Pl Def ANomAcc)) ++
-           tr (th "AF Fem Pl Def AGenDat" ++ td (x.s ! AF Fem Pl Def AGenDat)) ++
-           tr (th "AF Fem Pl Def AVoc" ++ td (x.s ! AF Fem Pl Def AVoc)) ++
-           tr (th "AA" ++ td (x.s ! AA))) ;
+           tr (th "Masc Sg Indef gen/dat" ++ td (x.s ! AF Masc Sg Indef AGenDat)) ++
+           tr (th "Masc Sg Indef voc" ++ td (x.s ! AF Masc Sg Indef AVoc)) ++
+           tr (th "Masc Sg Def nom/acc" ++ td (x.s ! AF Masc Sg Def ANomAcc)) ++
+           tr (th "Masc Sg Def gen/dat" ++ td (x.s ! AF Masc Sg Def AGenDat)) ++
+           tr (th "Masc Sg Def voc" ++ td (x.s ! AF Masc Sg Def AVoc)) ++
+           tr (th "Masc Pl Indef nom/acc" ++ td (x.s ! AF Masc Pl Indef ANomAcc)) ++
+           tr (th "Masc Pl Indef gen/dat" ++ td (x.s ! AF Masc Pl Indef AGenDat)) ++
+           tr (th "Masc Pl Indef voc" ++ td (x.s ! AF Masc Pl Indef AVoc)) ++
+           tr (th "Masc Pl Def nom/acc" ++ td (x.s ! AF Masc Pl Def ANomAcc)) ++
+           tr (th "Masc Pl Def gen/dat" ++ td (x.s ! AF Masc Pl Def AGenDat)) ++
+           tr (th "Masc Pl Def voc" ++ td (x.s ! AF Masc Pl Def AVoc)) ++
+           tr (th "Fem Sg Indef nom/acc" ++ td (x.s ! AF Fem Sg Indef ANomAcc)) ++
+           tr (th "Fem Sg Indef gen/dat" ++ td (x.s ! AF Fem Sg Indef AGenDat)) ++
+           tr (th "Fem Sg Indef voc" ++ td (x.s ! AF Fem Sg Indef AVoc)) ++
+           tr (th "Fem Sg Def nom/acc" ++ td (x.s ! AF Fem Sg Def ANomAcc)) ++
+           tr (th "Fem Sg Def gen/dat" ++ td (x.s ! AF Fem Sg Def AGenDat)) ++
+           tr (th "Fem Sg Def voc" ++ td (x.s ! AF Fem Sg Def AVoc)) ++
+           tr (th "Fem Pl Indef nom/acc" ++ td (x.s ! AF Fem Pl Indef ANomAcc)) ++
+           tr (th "Fem Pl Indef gen/dat" ++ td (x.s ! AF Fem Pl Indef AGenDat)) ++
+           tr (th "Fem Pl Indef voc" ++ td (x.s ! AF Fem Pl Indef AVoc)) ++
+           tr (th "Fem Pl Def nom/acc" ++ td (x.s ! AF Fem Pl Def ANomAcc)) ++
+           tr (th "Fem Pl Def gen/dat" ++ td (x.s ! AF Fem Pl Def AGenDat)) ++
+           tr (th "Fem Pl Def voc" ++ td (x.s ! AF Fem Pl Def AVoc)) ++
+           tr (th "" ++ td (x.s ! AA))) ;
       s3=[]
     } ;
 lin InflectionAdA = \x -> {
       t="ada" ;
       s1="" ;
-      s2=frameTable (
-           tr (th "s" ++ td (x.s))) ;
+      s2=paragraph x.s ;
       s3=[]
     } ;
 lin InflectionAdN = \x -> {
       t="adn" ;
       s1="" ;
-      s2=frameTable (
-           tr (th "s" ++ td (x.s))) ;
+      s2=paragraph x.s ;
       s3=[]
     } ;
 lin InflectionAdV, InflectionAdv = \x -> {
       t="adv" ;
       s1="" ;
-      s2=frameTable (
-           tr (th "s" ++ td (x.s))) ;
+      s2=paragraph x.s ;
       s3=[]
     } ;
 lin InflectionGN = \x -> {
@@ -199,18 +196,15 @@ lin InflectionVV = \x -> {
 oper
   inflNoun : Noun -> Str = \x ->
       frameTable (
-           tr (intagAttr "th" "rowspan=\"6\"" "Sg" ++ intagAttr "th" "rowspan=\"3\"" "Indef" ++ th "ANomAcc" ++ td (x.s ! Sg ! Indef ! ANomAcc)) ++
-           tr (th "AGenDat" ++ td (x.s ! Sg ! Indef ! AGenDat)) ++
-           tr (th "AVoc" ++ td (x.s ! Sg ! Indef ! AVoc)) ++
-           tr (intagAttr "th" "rowspan=\"3\"" "Def" ++ th "ANomAcc" ++ td (x.s ! Sg ! Def ! ANomAcc)) ++
-           tr (th "AGenDat" ++ td (x.s ! Sg ! Def ! AGenDat)) ++
-           tr (th "AVoc" ++ td (x.s ! Sg ! Def ! AVoc)) ++
-           tr (intagAttr "th" "rowspan=\"6\"" "Pl" ++ intagAttr "th" "rowspan=\"3\"" "Indef" ++ th "ANomAcc" ++ td (x.s ! Pl ! Indef ! ANomAcc)) ++
-           tr (th "AGenDat" ++ td (x.s ! Pl ! Indef ! AGenDat)) ++
-           tr (th "AVoc" ++ td (x.s ! Pl ! Indef ! AVoc)) ++
-           tr (intagAttr "th" "rowspan=\"3\"" "Def" ++ th "ANomAcc" ++ td (x.s ! Pl ! Def ! ANomAcc)) ++
-           tr (th "AGenDat" ++ td (x.s ! Pl ! Def ! AGenDat)) ++
-           tr (th "AVoc" ++ td (x.s ! Pl ! Def ! AVoc))) ;
+           tr (th "" ++ th "Sg" ++ th "Pl") ++
+           tr (intagAttr "th" "colspan=\"3\"" "Indef") ++ 
+           tr (th "nom/acc" ++ td (x.s ! Sg ! Indef ! ANomAcc) ++ td (x.s ! Pl ! Indef ! ANomAcc)) ++
+           tr (th "gen/dat" ++ td (x.s ! Sg ! Indef ! AGenDat) ++ td (x.s ! Pl ! Indef ! AGenDat)) ++
+           tr (th "voc"     ++ td (x.s ! Sg ! Indef ! AVoc)    ++ td (x.s ! Pl ! Indef ! AVoc)) ++
+           tr (intagAttr "th" "colspan=\"3\"" "Def") ++
+           tr (th "nom/acc" ++ td (x.s ! Sg ! Def ! ANomAcc) ++ td (x.s ! Pl ! Def ! ANomAcc)) ++
+           tr (th "gen/dat" ++ td (x.s ! Sg ! Def ! AGenDat) ++ td (x.s ! Pl ! Def ! AGenDat)) ++
+           tr (th "voc"     ++ td (x.s ! Sg ! Def ! AVoc)    ++ td (x.s ! Pl ! Def ! AVoc))) ;
 
   inflVerb : Verb -> Str = \x ->
       frameTable (

--- a/src/romanian/DocumentationRon.gf
+++ b/src/romanian/DocumentationRon.gf
@@ -11,31 +11,26 @@ lin InflectionA, InflectionA2 = \x -> {
       t="a" ;
       s1="" ;
       s2=frameTable (
-           tr (intagAttr "th" "rowspan=\"25\"" "s" ++ th "AF Masc Sg Indef ANomAcc" ++ td (x.s ! AF Masc Sg Indef ANomAcc)) ++
-           tr (th "Masc Sg Indef gen/dat" ++ td (x.s ! AF Masc Sg Indef AGenDat)) ++
-           tr (th "Masc Sg Indef voc" ++ td (x.s ! AF Masc Sg Indef AVoc)) ++
-           tr (th "Masc Sg Def nom/acc" ++ td (x.s ! AF Masc Sg Def ANomAcc)) ++
-           tr (th "Masc Sg Def gen/dat" ++ td (x.s ! AF Masc Sg Def AGenDat)) ++
-           tr (th "Masc Sg Def voc" ++ td (x.s ! AF Masc Sg Def AVoc)) ++
-           tr (th "Masc Pl Indef nom/acc" ++ td (x.s ! AF Masc Pl Indef ANomAcc)) ++
-           tr (th "Masc Pl Indef gen/dat" ++ td (x.s ! AF Masc Pl Indef AGenDat)) ++
-           tr (th "Masc Pl Indef voc" ++ td (x.s ! AF Masc Pl Indef AVoc)) ++
-           tr (th "Masc Pl Def nom/acc" ++ td (x.s ! AF Masc Pl Def ANomAcc)) ++
-           tr (th "Masc Pl Def gen/dat" ++ td (x.s ! AF Masc Pl Def AGenDat)) ++
-           tr (th "Masc Pl Def voc" ++ td (x.s ! AF Masc Pl Def AVoc)) ++
-           tr (th "Fem Sg Indef nom/acc" ++ td (x.s ! AF Fem Sg Indef ANomAcc)) ++
-           tr (th "Fem Sg Indef gen/dat" ++ td (x.s ! AF Fem Sg Indef AGenDat)) ++
-           tr (th "Fem Sg Indef voc" ++ td (x.s ! AF Fem Sg Indef AVoc)) ++
-           tr (th "Fem Sg Def nom/acc" ++ td (x.s ! AF Fem Sg Def ANomAcc)) ++
-           tr (th "Fem Sg Def gen/dat" ++ td (x.s ! AF Fem Sg Def AGenDat)) ++
-           tr (th "Fem Sg Def voc" ++ td (x.s ! AF Fem Sg Def AVoc)) ++
-           tr (th "Fem Pl Indef nom/acc" ++ td (x.s ! AF Fem Pl Indef ANomAcc)) ++
-           tr (th "Fem Pl Indef gen/dat" ++ td (x.s ! AF Fem Pl Indef AGenDat)) ++
-           tr (th "Fem Pl Indef voc" ++ td (x.s ! AF Fem Pl Indef AVoc)) ++
-           tr (th "Fem Pl Def nom/acc" ++ td (x.s ! AF Fem Pl Def ANomAcc)) ++
-           tr (th "Fem Pl Def gen/dat" ++ td (x.s ! AF Fem Pl Def AGenDat)) ++
-           tr (th "Fem Pl Def voc" ++ td (x.s ! AF Fem Pl Def AVoc)) ++
-           tr (th "" ++ td (x.s ! AA))) ;
+           tr (intagAttr "th" "colspan=\"2\"" "" ++ th "Sg" ++ th "Pl") ++
+           tr (intagAttr "th" "colspan=\"4\"" "Indef") ++
+           tr (intagAttr "th" "rowspan=\"3\"" "masc" ++
+               th "nom/acc" ++ td (x.s ! AF Masc Sg Indef ANomAcc) ++ td (x.s ! AF Masc Pl Indef ANomAcc)) ++
+           tr (th "gen/dat" ++ td (x.s ! AF Masc Sg Indef AGenDat) ++ td (x.s ! AF Masc Pl Indef AGenDat)) ++
+           tr (th "voc"     ++ td (x.s ! AF Masc Sg Indef AVoc)    ++ td (x.s ! AF Masc Pl Indef AVoc)) ++
+           tr (intagAttr "th" "rowspan=\"3\"" "fem" ++
+               th "nom/acc" ++ td (x.s ! AF Fem  Sg Indef ANomAcc) ++ td (x.s ! AF Fem  Pl Indef ANomAcc)) ++
+           tr (th "gen/dat" ++ td (x.s ! AF Fem  Sg Indef AGenDat) ++ td (x.s ! AF Fem  Pl Indef AGenDat)) ++
+           tr (th "voc"     ++ td (x.s ! AF Fem  Sg Indef AVoc)    ++ td (x.s ! AF Fem  Pl Indef AVoc)) ++
+           tr (intagAttr "th" "colspan=\"4\"" "Def") ++
+           tr (intagAttr "th" "rowspan=\"3\"" "masc" ++
+               th "om/acc" ++ td (x.s ! AF Masc Sg Def ANomAcc) ++ td (x.s ! AF Masc Pl Def ANomAcc)) ++
+           tr (th "gen/dat" ++ td (x.s ! AF Masc Sg Def AGenDat) ++ td (x.s ! AF Masc Pl Def AGenDat)) ++
+           tr (th "voc"     ++ td (x.s ! AF Masc Sg Def AVoc)    ++ td (x.s ! AF Masc Pl Def AVoc)) ++
+           tr (intagAttr "th" "rowspan=\"3\"" "fem" ++
+               th "nom/acc" ++ td (x.s ! AF Fem  Sg Def ANomAcc) ++ td (x.s ! AF Fem  Pl Def ANomAcc)) ++
+           tr (th "gen/dat" ++ td (x.s ! AF Fem  Sg Def AGenDat) ++ td (x.s ! AF Fem  Pl Def AGenDat)) ++
+           tr (th "voc"     ++ td (x.s ! AF Fem  Sg Def AVoc)    ++ td (x.s ! AF Fem  Pl Def AVoc))) ++
+           paragraph (x.s ! AA) ;
       s3=[]
     } ;
 lin InflectionAdA = \x -> {
@@ -197,7 +192,7 @@ oper
   inflNoun : Noun -> Str = \x ->
       frameTable (
            tr (th "" ++ th "Sg" ++ th "Pl") ++
-           tr (intagAttr "th" "colspan=\"3\"" "Indef") ++ 
+           tr (intagAttr "th" "colspan=\"3\"" "Indef") ++
            tr (th "nom/acc" ++ td (x.s ! Sg ! Indef ! ANomAcc) ++ td (x.s ! Pl ! Indef ! ANomAcc)) ++
            tr (th "gen/dat" ++ td (x.s ! Sg ! Indef ! AGenDat) ++ td (x.s ! Pl ! Indef ! AGenDat)) ++
            tr (th "voc"     ++ td (x.s ! Sg ! Indef ! AVoc)    ++ td (x.s ! Pl ! Indef ! AVoc)) ++
@@ -207,114 +202,61 @@ oper
            tr (th "voc"     ++ td (x.s ! Sg ! Def ! AVoc)    ++ td (x.s ! Pl ! Def ! AVoc))) ;
 
   inflVerb : Verb -> Str = \x ->
+      heading1 "Infinitive" ++
+      paragraph (x.s ! Inf) ++
+      heading1 "Indicative" ++
       frameTable (
-           tr (th "Inf" ++ td (x.s ! Inf)) ++
-           tr (th "Indi Presn Sg P1" ++ td (x.s ! Indi Presn Sg P1)) ++
-           tr (th "Indi Presn Sg P2" ++ td (x.s ! Indi Presn Sg P2)) ++
-           tr (th "Indi Presn Sg P3" ++ td (x.s ! Indi Presn Sg P3)) ++
-           tr (th "Indi Presn Pl P1" ++ td (x.s ! Indi Presn Pl P1)) ++
-           tr (th "Indi Presn Pl P2" ++ td (x.s ! Indi Presn Pl P2)) ++
-           tr (th "Indi Presn Pl P3" ++ td (x.s ! Indi Presn Pl P3)) ++
-           tr (th "Indi Imparf Sg P1" ++ td (x.s ! Indi Imparf Sg P1)) ++
-           tr (th "Indi Imparf Sg P2" ++ td (x.s ! Indi Imparf Sg P2)) ++
-           tr (th "Indi Imparf Sg P3" ++ td (x.s ! Indi Imparf Sg P3)) ++
-           tr (th "Indi Imparf Pl P1" ++ td (x.s ! Indi Imparf Pl P1)) ++
-           tr (th "Indi Imparf Pl P2" ++ td (x.s ! Indi Imparf Pl P2)) ++
-           tr (th "Indi Imparf Pl P3" ++ td (x.s ! Indi Imparf Pl P3)) ++
-           tr (th "Indi PSimple Sg P1" ++ td (x.s ! Indi PSimple Sg P1)) ++
-           tr (th "Indi PSimple Sg P2" ++ td (x.s ! Indi PSimple Sg P2)) ++
-           tr (th "Indi PSimple Sg P3" ++ td (x.s ! Indi PSimple Sg P3)) ++
-           tr (th "Indi PSimple Pl P1" ++ td (x.s ! Indi PSimple Pl P1)) ++
-           tr (th "Indi PSimple Pl P2" ++ td (x.s ! Indi PSimple Pl P2)) ++
-           tr (th "Indi PSimple Pl P3" ++ td (x.s ! Indi PSimple Pl P3)) ++
-           tr (th "Indi PPerfect Sg P1" ++ td (x.s ! Indi PPerfect Sg P1)) ++
-           tr (th "Indi PPerfect Sg P2" ++ td (x.s ! Indi PPerfect Sg P2)) ++
-           tr (th "Indi PPerfect Sg P3" ++ td (x.s ! Indi PPerfect Sg P3)) ++
-           tr (th "Indi PPerfect Pl P1" ++ td (x.s ! Indi PPerfect Pl P1)) ++
-           tr (th "Indi PPerfect Pl P2" ++ td (x.s ! Indi PPerfect Pl P2)) ++
-           tr (th "Indi PPerfect Pl P3" ++ td (x.s ! Indi PPerfect Pl P3)) ++
-           tr (th "Subjo SPres Sg P1" ++ td (x.s ! Subjo SPres Sg P1)) ++
-           tr (th "Subjo SPres Sg P2" ++ td (x.s ! Subjo SPres Sg P2)) ++
-           tr (th "Subjo SPres Sg P3" ++ td (x.s ! Subjo SPres Sg P3)) ++
-           tr (th "Subjo SPres Pl P1" ++ td (x.s ! Subjo SPres Pl P1)) ++
-           tr (th "Subjo SPres Pl P2" ++ td (x.s ! Subjo SPres Pl P2)) ++
-           tr (th "Subjo SPres Pl P3" ++ td (x.s ! Subjo SPres Pl P3)) ++
-           tr (th "Imper SgP2" ++ td (x.s ! Imper SgP2)) ++
-           tr (th "Imper PlP1" ++ td (x.s ! Imper PlP1)) ++
-           tr (th "Imper PlP2" ++ td (x.s ! Imper PlP2)) ++
-           tr (th "Ger" ++ td (x.s ! Ger)) ++
-           tr (th "PPasse Masc Sg Indef ANomAcc" ++ td (x.s ! PPasse Masc Sg Indef ANomAcc)) ++
-           tr (th "PPasse Masc Sg Indef AGenDat" ++ td (x.s ! PPasse Masc Sg Indef AGenDat)) ++
-           tr (th "PPasse Masc Sg Indef AVoc" ++ td (x.s ! PPasse Masc Sg Indef AVoc)) ++
-           tr (th "PPasse Masc Sg Def ANomAcc" ++ td (x.s ! PPasse Masc Sg Def ANomAcc)) ++
-           tr (th "PPasse Masc Sg Def AGenDat" ++ td (x.s ! PPasse Masc Sg Def AGenDat)) ++
-           tr (th "PPasse Masc Sg Def AVoc" ++ td (x.s ! PPasse Masc Sg Def AVoc)) ++
-           tr (th "PPasse Masc Pl Indef ANomAcc" ++ td (x.s ! PPasse Masc Pl Indef ANomAcc)) ++
-           tr (th "PPasse Masc Pl Indef AGenDat" ++ td (x.s ! PPasse Masc Pl Indef AGenDat)) ++
-           tr (th "PPasse Masc Pl Indef AVoc" ++ td (x.s ! PPasse Masc Pl Indef AVoc)) ++
-           tr (th "PPasse Masc Pl Def ANomAcc" ++ td (x.s ! PPasse Masc Pl Def ANomAcc)) ++
-           tr (th "PPasse Masc Pl Def AGenDat" ++ td (x.s ! PPasse Masc Pl Def AGenDat)) ++
-           tr (th "PPasse Masc Pl Def AVoc" ++ td (x.s ! PPasse Masc Pl Def AVoc)) ++
-           tr (th "PPasse Fem Sg Indef ANomAcc" ++ td (x.s ! PPasse Fem Sg Indef ANomAcc)) ++
-           tr (th "PPasse Fem Sg Indef AGenDat" ++ td (x.s ! PPasse Fem Sg Indef AGenDat)) ++
-           tr (th "PPasse Fem Sg Indef AVoc" ++ td (x.s ! PPasse Fem Sg Indef AVoc)) ++
-           tr (th "PPasse Fem Sg Def ANomAcc" ++ td (x.s ! PPasse Fem Sg Def ANomAcc)) ++
-           tr (th "PPasse Fem Sg Def AGenDat" ++ td (x.s ! PPasse Fem Sg Def AGenDat)) ++
-           tr (th "PPasse Fem Sg Def AVoc" ++ td (x.s ! PPasse Fem Sg Def AVoc)) ++
-           tr (th "PPasse Fem Pl Indef ANomAcc" ++ td (x.s ! PPasse Fem Pl Indef ANomAcc)) ++
-           tr (th "PPasse Fem Pl Indef AGenDat" ++ td (x.s ! PPasse Fem Pl Indef AGenDat)) ++
-           tr (th "PPasse Fem Pl Indef AVoc" ++ td (x.s ! PPasse Fem Pl Indef AVoc)) ++
-           tr (th "PPasse Fem Pl Def ANomAcc" ++ td (x.s ! PPasse Fem Pl Def ANomAcc)) ++
-           tr (th "PPasse Fem Pl Def AGenDat" ++ td (x.s ! PPasse Fem Pl Def AGenDat)) ++
-           tr (th "PPasse Fem Pl Def AVoc" ++ td (x.s ! PPasse Fem Pl Def AVoc)) ++
-           tr (intagAttr "th" "rowspan=\"48\"" "isRefl" ++ intagAttr "th" "rowspan=\"4\"" "{g=Masc; n=Sg; p=P1}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P1}).s ! Normal)) ++
-           tr (th "Composite" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P1}).s ! Composite)) ++
-           tr (th "Short" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P1}).s ! Short)) ++
-           tr (th "Imperative" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P1}).s ! Imperative)) ++
-           tr (intagAttr "th" "rowspan=\"4\"" "{g=Masc; n=Sg; p=P2}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P2}).s ! Normal)) ++
-           tr (th "Composite" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P2}).s ! Composite)) ++
-           tr (th "Short" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P2}).s ! Short)) ++
-           tr (th "Imperative" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P2}).s ! Imperative)) ++
-           tr (intagAttr "th" "rowspan=\"4\"" "{g=Masc; n=Sg; p=P3}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P3}).s ! Normal)) ++
-           tr (th "Composite" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P3}).s ! Composite)) ++
-           tr (th "Short" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P3}).s ! Short)) ++
-           tr (th "Imperative" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P3}).s ! Imperative)) ++
-           tr (intagAttr "th" "rowspan=\"4\"" "{g=Masc; n=Pl; p=P1}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P1}).s ! Normal)) ++
-           tr (th "Composite" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P1}).s ! Composite)) ++
-           tr (th "Short" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P1}).s ! Short)) ++
-           tr (th "Imperative" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P1}).s ! Imperative)) ++
-           tr (intagAttr "th" "rowspan=\"4\"" "{g=Masc; n=Pl; p=P2}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P2}).s ! Normal)) ++
-           tr (th "Composite" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P2}).s ! Composite)) ++
-           tr (th "Short" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P2}).s ! Short)) ++
-           tr (th "Imperative" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P2}).s ! Imperative)) ++
-           tr (intagAttr "th" "rowspan=\"4\"" "{g=Masc; n=Pl; p=P3}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P3}).s ! Normal)) ++
-           tr (th "Composite" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P3}).s ! Composite)) ++
-           tr (th "Short" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P3}).s ! Short)) ++
-           tr (th "Imperative" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P3}).s ! Imperative)) ++
-           tr (intagAttr "th" "rowspan=\"4\"" "{g=Fem; n=Sg; p=P1}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P1}).s ! Normal)) ++
-           tr (th "Composite" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P1}).s ! Composite)) ++
-           tr (th "Short" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P1}).s ! Short)) ++
-           tr (th "Imperative" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P1}).s ! Imperative)) ++
-           tr (intagAttr "th" "rowspan=\"4\"" "{g=Fem; n=Sg; p=P2}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P2}).s ! Normal)) ++
-           tr (th "Composite" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P2}).s ! Composite)) ++
-           tr (th "Short" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P2}).s ! Short)) ++
-           tr (th "Imperative" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P2}).s ! Imperative)) ++
-           tr (intagAttr "th" "rowspan=\"4\"" "{g=Fem; n=Sg; p=P3}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P3}).s ! Normal)) ++
-           tr (th "Composite" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P3}).s ! Composite)) ++
-           tr (th "Short" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P3}).s ! Short)) ++
-           tr (th "Imperative" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P3}).s ! Imperative)) ++
-           tr (intagAttr "th" "rowspan=\"4\"" "{g=Fem; n=Pl; p=P1}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P1}).s ! Normal)) ++
-           tr (th "Composite" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P1}).s ! Composite)) ++
-           tr (th "Short" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P1}).s ! Short)) ++
-           tr (th "Imperative" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P1}).s ! Imperative)) ++
-           tr (intagAttr "th" "rowspan=\"4\"" "{g=Fem; n=Pl; p=P2}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P2}).s ! Normal)) ++
-           tr (th "Composite" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P2}).s ! Composite)) ++
-           tr (th "Short" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P2}).s ! Short)) ++
-           tr (th "Imperative" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P2}).s ! Imperative)) ++
-           tr (intagAttr "th" "rowspan=\"4\"" "{g=Fem; n=Pl; p=P3}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P3}).s ! Normal)) ++
-           tr (th "Composite" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P3}).s ! Composite)) ++
-           tr (th "Short" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P3}).s ! Short)) ++
-           tr (th "Imperative" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P3}).s ! Imperative))) ;
+           tr (th "" ++ th "Sg" ++ th "Pl") ++
+           tr (intagAttr "th" "colspan=\"3\"" "Presn") ++
+           tr (th "1p" ++ td (x.s ! Indi Presn Sg P1) ++ td (x.s ! Indi Presn Pl P1)) ++
+           tr (th "2p" ++ td (x.s ! Indi Presn Sg P2) ++ td (x.s ! Indi Presn Pl P2)) ++
+           tr (th "3p" ++ td (x.s ! Indi Presn Sg P3) ++ td (x.s ! Indi Presn Pl P3)) ++
+           tr (intagAttr "th" "colspan=\"3\"" "Imparf") ++
+           tr (th "1p" ++ td (x.s ! Indi Imparf Sg P1) ++ td (x.s ! Indi Imparf Pl P1)) ++
+           tr (th "2p" ++ td (x.s ! Indi Imparf Sg P2) ++ td (x.s ! Indi Imparf Pl P2)) ++
+           tr (th "3p" ++ td (x.s ! Indi Imparf Sg P3) ++ td (x.s ! Indi Imparf Pl P3)) ++
+           tr (intagAttr "th" "colspan=\"3\"" "Simple") ++
+           tr (th "1p" ++ td (x.s ! Indi PSimple Sg P1) ++ td (x.s ! Indi PSimple Pl P1)) ++
+           tr (th "2p" ++ td (x.s ! Indi PSimple Sg P2) ++ td (x.s ! Indi PSimple Pl P2)) ++
+           tr (th "3p" ++ td (x.s ! Indi PSimple Sg P3) ++ td (x.s ! Indi PSimple Pl P3)) ++
+           tr (intagAttr "th" "colspan=\"3\"" "Perfect") ++
+           tr (th "1p" ++ td (x.s ! Indi PPerfect Sg P1) ++ td (x.s ! Indi PPerfect Pl P1)) ++
+           tr (th "2p" ++ td (x.s ! Indi PPerfect Sg P2) ++ td (x.s ! Indi PPerfect Pl P2)) ++
+           tr (th "3p" ++ td (x.s ! Indi PPerfect Sg P3) ++ td (x.s ! Indi PPerfect Pl P3))) ++
+      heading1 "Subjunctive" ++
+      frameTable (
+           tr (th "" ++ th "Sg" ++ th "Pl") ++
+           tr (th "1p" ++ td (x.s ! Subjo SPres Sg P1) ++ td (x.s ! Subjo SPres Pl P1)) ++
+           tr (th "2p" ++ td (x.s ! Subjo SPres Sg P2) ++ td (x.s ! Subjo SPres Pl P2)) ++
+           tr (th "3p" ++ td (x.s ! Subjo SPres Sg P3) ++ td (x.s ! Subjo SPres Pl P3))) ++
+      heading1 "Imperative" ++
+      frameTable (
+           tr (th "Sg 2p" ++ td (x.s ! Imper SgP2)) ++
+           tr (th "Pl 1p" ++ td (x.s ! Imper PlP1)) ++
+           tr (th "Pl 2p" ++ td (x.s ! Imper PlP2))) ++
+      heading1 "Gerund" ++
+      paragraph (x.s ! Ger) ++
+      heading1 "Passe" ++
+      frameTable (
+           tr (intagAttr "th" "colspan=\"2\"" "" ++ th "Sg" ++ th "Pl") ++
+           tr (intagAttr "th" "colspan=\"4\"" "Indef") ++
+           tr (intagAttr "th" "rowspan=\"3\"" "masc" ++
+               th "nom/acc" ++ td (x.s ! PPasse Masc Sg Indef ANomAcc) ++ td (x.s ! PPasse Masc Pl Indef ANomAcc)) ++
+           tr (th "gen/dat" ++ td (x.s ! PPasse Masc Sg Indef AGenDat) ++ td (x.s ! PPasse Masc Pl Indef AGenDat)) ++
+           tr (th "voc"     ++ td (x.s ! PPasse Masc Sg Indef AVoc)    ++ td (x.s ! PPasse Masc Pl Indef AVoc)) ++
+           tr (intagAttr "th" "rowspan=\"3\"" "fem" ++
+               th "nom/acc" ++ td (x.s ! PPasse Fem  Sg Indef ANomAcc) ++ td (x.s ! PPasse Fem  Pl Indef ANomAcc)) ++
+           tr (th "gen/dat" ++ td (x.s ! PPasse Fem  Sg Indef AGenDat) ++ td (x.s ! PPasse Fem  Pl Indef AGenDat)) ++
+           tr (th "voc"     ++ td (x.s ! PPasse Fem  Sg Indef AVoc)    ++ td (x.s ! PPasse Fem  Pl Indef AVoc)) ++
+           tr (intagAttr "th" "colspan=\"4\"" "Def") ++
+           tr (intagAttr "th" "rowspan=\"3\"" "masc" ++
+               th "nom/acc" ++ td (x.s ! PPasse Masc Sg Def ANomAcc)   ++ td (x.s ! PPasse Masc Pl Def ANomAcc)) ++
+           tr (th "gen/dat" ++ td (x.s ! PPasse Masc Sg Def AGenDat)   ++ td (x.s ! PPasse Masc Pl Def AGenDat)) ++
+           tr (th "voc"     ++ td (x.s ! PPasse Masc Sg Def AVoc)      ++ td (x.s ! PPasse Masc Pl Def AVoc)) ++
+           tr (intagAttr "th" "rowspan=\"3\"" "fem" ++
+               th "nom/acc" ++ td (x.s ! PPasse Fem  Sg Def ANomAcc)   ++ td (x.s ! PPasse Fem  Pl Def ANomAcc)) ++
+           tr (th "gen/dat" ++ td (x.s ! PPasse Fem  Sg Def AGenDat)   ++ td (x.s ! PPasse Fem  Pl Def AGenDat)) ++
+           tr (th "voc"     ++ td (x.s ! PPasse Fem  Sg Def AVoc)      ++ td (x.s ! PPasse Fem  Pl Def AVoc))) ;
 
 lin
   NoDefinition   t     = {s=t.s};

--- a/src/romanian/DocumentationRon.gf
+++ b/src/romanian/DocumentationRon.gf
@@ -1,0 +1,329 @@
+concrete DocumentationRon of Documentation = CatRon ** open
+  ResRon, Prelude, HTML in {
+
+lincat
+  Inflection = {t : Str; s1,s2,s3 : Str} ;
+  Definition = {s : Str} ;
+  Document   = {s : Str} ;
+  Tag        = {s : Str} ;
+
+lin InflectionA, InflectionA2 = \x -> {
+      t="a" ;
+      s1="" ;
+      s2=frameTable (
+           tr (intagAttr "th" "rowspan=\"25\"" "s" ++ th "AF Masc Sg Indef ANomAcc" ++ td (x.s ! AF Masc Sg Indef ANomAcc)) ++
+           tr (th "AF Masc Sg Indef AGenDat" ++ td (x.s ! AF Masc Sg Indef AGenDat)) ++
+           tr (th "AF Masc Sg Indef AVoc" ++ td (x.s ! AF Masc Sg Indef AVoc)) ++
+           tr (th "AF Masc Sg Def ANomAcc" ++ td (x.s ! AF Masc Sg Def ANomAcc)) ++
+           tr (th "AF Masc Sg Def AGenDat" ++ td (x.s ! AF Masc Sg Def AGenDat)) ++
+           tr (th "AF Masc Sg Def AVoc" ++ td (x.s ! AF Masc Sg Def AVoc)) ++
+           tr (th "AF Masc Pl Indef ANomAcc" ++ td (x.s ! AF Masc Pl Indef ANomAcc)) ++
+           tr (th "AF Masc Pl Indef AGenDat" ++ td (x.s ! AF Masc Pl Indef AGenDat)) ++
+           tr (th "AF Masc Pl Indef AVoc" ++ td (x.s ! AF Masc Pl Indef AVoc)) ++
+           tr (th "AF Masc Pl Def ANomAcc" ++ td (x.s ! AF Masc Pl Def ANomAcc)) ++
+           tr (th "AF Masc Pl Def AGenDat" ++ td (x.s ! AF Masc Pl Def AGenDat)) ++
+           tr (th "AF Masc Pl Def AVoc" ++ td (x.s ! AF Masc Pl Def AVoc)) ++
+           tr (th "AF Fem Sg Indef ANomAcc" ++ td (x.s ! AF Fem Sg Indef ANomAcc)) ++
+           tr (th "AF Fem Sg Indef AGenDat" ++ td (x.s ! AF Fem Sg Indef AGenDat)) ++
+           tr (th "AF Fem Sg Indef AVoc" ++ td (x.s ! AF Fem Sg Indef AVoc)) ++
+           tr (th "AF Fem Sg Def ANomAcc" ++ td (x.s ! AF Fem Sg Def ANomAcc)) ++
+           tr (th "AF Fem Sg Def AGenDat" ++ td (x.s ! AF Fem Sg Def AGenDat)) ++
+           tr (th "AF Fem Sg Def AVoc" ++ td (x.s ! AF Fem Sg Def AVoc)) ++
+           tr (th "AF Fem Pl Indef ANomAcc" ++ td (x.s ! AF Fem Pl Indef ANomAcc)) ++
+           tr (th "AF Fem Pl Indef AGenDat" ++ td (x.s ! AF Fem Pl Indef AGenDat)) ++
+           tr (th "AF Fem Pl Indef AVoc" ++ td (x.s ! AF Fem Pl Indef AVoc)) ++
+           tr (th "AF Fem Pl Def ANomAcc" ++ td (x.s ! AF Fem Pl Def ANomAcc)) ++
+           tr (th "AF Fem Pl Def AGenDat" ++ td (x.s ! AF Fem Pl Def AGenDat)) ++
+           tr (th "AF Fem Pl Def AVoc" ++ td (x.s ! AF Fem Pl Def AVoc)) ++
+           tr (th "AA" ++ td (x.s ! AA))) ;
+      s3=[]
+    } ;
+lin InflectionAdA = \x -> {
+      t="ada" ;
+      s1="" ;
+      s2=frameTable (
+           tr (th "s" ++ td (x.s))) ;
+      s3=[]
+    } ;
+lin InflectionAdN = \x -> {
+      t="adn" ;
+      s1="" ;
+      s2=frameTable (
+           tr (th "s" ++ td (x.s))) ;
+      s3=[]
+    } ;
+lin InflectionAdV, InflectionAdv = \x -> {
+      t="adv" ;
+      s1="" ;
+      s2=frameTable (
+           tr (th "s" ++ td (x.s))) ;
+      s3=[]
+    } ;
+lin InflectionGN = \x -> {
+      t="gn" ;
+      s1="" ;
+      s2=frameTable (
+           tr (intagAttr "th" "rowspan=\"5\"" "s" ++ th "No" ++ td (x.s ! No)) ++
+           tr (th "Da" ++ td (x.s ! Da)) ++
+           tr (th "Ac" ++ td (x.s ! Ac)) ++
+           tr (th "Ge" ++ td (x.s ! Ge)) ++
+           tr (th "Vo" ++ td (x.s ! Vo))) ;
+      s3=[]
+    } ;
+lin InflectionLN = \x -> {
+      t="ln" ;
+      s1="" ;
+      s2=frameTable (
+           tr (intagAttr "th" "rowspan=\"5\"" "s" ++ th "No" ++ td (x.s ! No)) ++
+           tr (th "Da" ++ td (x.s ! Da)) ++
+           tr (th "Ac" ++ td (x.s ! Ac)) ++
+           tr (th "Ge" ++ td (x.s ! Ge)) ++
+           tr (th "Vo" ++ td (x.s ! Vo))) ;
+      s3=[]
+    } ;
+lin InflectionN = \x -> {
+      t="n" ;
+      s1="" ;
+      s2=inflNoun x ;
+      s3=[]
+    } ;
+lin InflectionN2 = \x -> {
+      t="n2" ;
+      s1="" ;
+      s2=inflNoun x ;
+      s3=[]
+    } ;
+lin InflectionN3 = \x -> {
+      t="n3" ;
+      s1="" ;
+      s2=inflNoun x ;
+      s3=[]
+    } ;
+lin InflectionPN = \x -> {
+      t="pn" ;
+      s1="" ;
+      s2=frameTable (
+           tr (intagAttr "th" "rowspan=\"5\"" "s" ++ th "No" ++ td (x.s ! No)) ++
+           tr (th "Da" ++ td (x.s ! Da)) ++
+           tr (th "Ac" ++ td (x.s ! Ac)) ++
+           tr (th "Ge" ++ td (x.s ! Ge)) ++
+           tr (th "Vo" ++ td (x.s ! Vo))) ;
+      s3=[]
+    } ;
+lin InflectionPrep = \x -> {
+      t="prep" ;
+      s1="" ;
+      s2=frameTable (
+           tr (th "s" ++ td (x.s)) ++
+           tr (th "prepDir" ++ td (x.prepDir))) ;
+      s3=[]
+    } ;
+lin InflectionSN = \x -> {
+      t="sn" ;
+      s1="" ;
+      s2=frameTable (
+           tr (intagAttr "th" "rowspan=\"5\"" "s" ++ th "No" ++ td (x.s ! No)) ++
+           tr (th "Da" ++ td (x.s ! Da)) ++
+           tr (th "Ac" ++ td (x.s ! Ac)) ++
+           tr (th "Ge" ++ td (x.s ! Ge)) ++
+           tr (th "Vo" ++ td (x.s ! Vo))) ;
+      s3=[]
+    } ;
+lin InflectionV = \x -> {
+      t="v" ;
+      s1="" ;
+      s2=inflVerb x ;
+      s3=[]
+    } ;
+lin InflectionV2 = \x -> {
+      t="v2" ;
+      s1="" ;
+      s2=inflVerb x ;
+      s3=[]
+    } ;
+lin InflectionV2A = \x -> {
+      t="v2a" ;
+      s1="" ;
+      s2=inflVerb x ;
+      s3=[]
+    } ;
+lin InflectionV2Q = \x -> {
+      t="v2q" ;
+      s1="" ;
+      s2=inflVerb x ;
+      s3=[]
+    } ;
+lin InflectionV2S = \x -> {
+      t="v2s" ;
+      s1="" ;
+      s2=inflVerb x ;
+      s3=[]
+    } ;
+lin InflectionV2V = \x -> {
+      t="v2v" ;
+      s1="" ;
+      s2=inflVerb x ;
+      s3=[]
+    } ;
+lin InflectionV3 = \x -> {
+      t="v3" ;
+      s1="" ;
+      s2=inflVerb x ;
+      s3=[]
+    } ;
+lin InflectionVA = \x -> {
+      t="va" ;
+      s1="" ;
+      s2=inflVerb x ;
+      s3=[]
+    } ;
+lin InflectionVQ = \x -> {
+      t="vq" ;
+      s1="" ;
+      s2=inflVerb x ;
+      s3=[]
+    } ;
+lin InflectionVS = \x -> {
+      t="vs" ;
+      s1="" ;
+      s2=inflVerb x ;
+      s3=[]
+    } ;
+lin InflectionVV = \x -> {
+      t="vv" ;
+      s1="" ;
+      s2=inflVerb x ;
+      s3=[]
+    } ;
+
+oper
+  inflNoun : Noun -> Str = \x ->
+      frameTable (
+           tr (intagAttr "th" "rowspan=\"6\"" "Sg" ++ intagAttr "th" "rowspan=\"3\"" "Indef" ++ th "ANomAcc" ++ td (x.s ! Sg ! Indef ! ANomAcc)) ++
+           tr (th "AGenDat" ++ td (x.s ! Sg ! Indef ! AGenDat)) ++
+           tr (th "AVoc" ++ td (x.s ! Sg ! Indef ! AVoc)) ++
+           tr (intagAttr "th" "rowspan=\"3\"" "Def" ++ th "ANomAcc" ++ td (x.s ! Sg ! Def ! ANomAcc)) ++
+           tr (th "AGenDat" ++ td (x.s ! Sg ! Def ! AGenDat)) ++
+           tr (th "AVoc" ++ td (x.s ! Sg ! Def ! AVoc)) ++
+           tr (intagAttr "th" "rowspan=\"6\"" "Pl" ++ intagAttr "th" "rowspan=\"3\"" "Indef" ++ th "ANomAcc" ++ td (x.s ! Pl ! Indef ! ANomAcc)) ++
+           tr (th "AGenDat" ++ td (x.s ! Pl ! Indef ! AGenDat)) ++
+           tr (th "AVoc" ++ td (x.s ! Pl ! Indef ! AVoc)) ++
+           tr (intagAttr "th" "rowspan=\"3\"" "Def" ++ th "ANomAcc" ++ td (x.s ! Pl ! Def ! ANomAcc)) ++
+           tr (th "AGenDat" ++ td (x.s ! Pl ! Def ! AGenDat)) ++
+           tr (th "AVoc" ++ td (x.s ! Pl ! Def ! AVoc))) ;
+
+  inflVerb : Verb -> Str = \x ->
+      frameTable (
+           tr (th "Inf" ++ td (x.s ! Inf)) ++
+           tr (th "Indi Presn Sg P1" ++ td (x.s ! Indi Presn Sg P1)) ++
+           tr (th "Indi Presn Sg P2" ++ td (x.s ! Indi Presn Sg P2)) ++
+           tr (th "Indi Presn Sg P3" ++ td (x.s ! Indi Presn Sg P3)) ++
+           tr (th "Indi Presn Pl P1" ++ td (x.s ! Indi Presn Pl P1)) ++
+           tr (th "Indi Presn Pl P2" ++ td (x.s ! Indi Presn Pl P2)) ++
+           tr (th "Indi Presn Pl P3" ++ td (x.s ! Indi Presn Pl P3)) ++
+           tr (th "Indi Imparf Sg P1" ++ td (x.s ! Indi Imparf Sg P1)) ++
+           tr (th "Indi Imparf Sg P2" ++ td (x.s ! Indi Imparf Sg P2)) ++
+           tr (th "Indi Imparf Sg P3" ++ td (x.s ! Indi Imparf Sg P3)) ++
+           tr (th "Indi Imparf Pl P1" ++ td (x.s ! Indi Imparf Pl P1)) ++
+           tr (th "Indi Imparf Pl P2" ++ td (x.s ! Indi Imparf Pl P2)) ++
+           tr (th "Indi Imparf Pl P3" ++ td (x.s ! Indi Imparf Pl P3)) ++
+           tr (th "Indi PSimple Sg P1" ++ td (x.s ! Indi PSimple Sg P1)) ++
+           tr (th "Indi PSimple Sg P2" ++ td (x.s ! Indi PSimple Sg P2)) ++
+           tr (th "Indi PSimple Sg P3" ++ td (x.s ! Indi PSimple Sg P3)) ++
+           tr (th "Indi PSimple Pl P1" ++ td (x.s ! Indi PSimple Pl P1)) ++
+           tr (th "Indi PSimple Pl P2" ++ td (x.s ! Indi PSimple Pl P2)) ++
+           tr (th "Indi PSimple Pl P3" ++ td (x.s ! Indi PSimple Pl P3)) ++
+           tr (th "Indi PPerfect Sg P1" ++ td (x.s ! Indi PPerfect Sg P1)) ++
+           tr (th "Indi PPerfect Sg P2" ++ td (x.s ! Indi PPerfect Sg P2)) ++
+           tr (th "Indi PPerfect Sg P3" ++ td (x.s ! Indi PPerfect Sg P3)) ++
+           tr (th "Indi PPerfect Pl P1" ++ td (x.s ! Indi PPerfect Pl P1)) ++
+           tr (th "Indi PPerfect Pl P2" ++ td (x.s ! Indi PPerfect Pl P2)) ++
+           tr (th "Indi PPerfect Pl P3" ++ td (x.s ! Indi PPerfect Pl P3)) ++
+           tr (th "Subjo SPres Sg P1" ++ td (x.s ! Subjo SPres Sg P1)) ++
+           tr (th "Subjo SPres Sg P2" ++ td (x.s ! Subjo SPres Sg P2)) ++
+           tr (th "Subjo SPres Sg P3" ++ td (x.s ! Subjo SPres Sg P3)) ++
+           tr (th "Subjo SPres Pl P1" ++ td (x.s ! Subjo SPres Pl P1)) ++
+           tr (th "Subjo SPres Pl P2" ++ td (x.s ! Subjo SPres Pl P2)) ++
+           tr (th "Subjo SPres Pl P3" ++ td (x.s ! Subjo SPres Pl P3)) ++
+           tr (th "Imper SgP2" ++ td (x.s ! Imper SgP2)) ++
+           tr (th "Imper PlP1" ++ td (x.s ! Imper PlP1)) ++
+           tr (th "Imper PlP2" ++ td (x.s ! Imper PlP2)) ++
+           tr (th "Ger" ++ td (x.s ! Ger)) ++
+           tr (th "PPasse Masc Sg Indef ANomAcc" ++ td (x.s ! PPasse Masc Sg Indef ANomAcc)) ++
+           tr (th "PPasse Masc Sg Indef AGenDat" ++ td (x.s ! PPasse Masc Sg Indef AGenDat)) ++
+           tr (th "PPasse Masc Sg Indef AVoc" ++ td (x.s ! PPasse Masc Sg Indef AVoc)) ++
+           tr (th "PPasse Masc Sg Def ANomAcc" ++ td (x.s ! PPasse Masc Sg Def ANomAcc)) ++
+           tr (th "PPasse Masc Sg Def AGenDat" ++ td (x.s ! PPasse Masc Sg Def AGenDat)) ++
+           tr (th "PPasse Masc Sg Def AVoc" ++ td (x.s ! PPasse Masc Sg Def AVoc)) ++
+           tr (th "PPasse Masc Pl Indef ANomAcc" ++ td (x.s ! PPasse Masc Pl Indef ANomAcc)) ++
+           tr (th "PPasse Masc Pl Indef AGenDat" ++ td (x.s ! PPasse Masc Pl Indef AGenDat)) ++
+           tr (th "PPasse Masc Pl Indef AVoc" ++ td (x.s ! PPasse Masc Pl Indef AVoc)) ++
+           tr (th "PPasse Masc Pl Def ANomAcc" ++ td (x.s ! PPasse Masc Pl Def ANomAcc)) ++
+           tr (th "PPasse Masc Pl Def AGenDat" ++ td (x.s ! PPasse Masc Pl Def AGenDat)) ++
+           tr (th "PPasse Masc Pl Def AVoc" ++ td (x.s ! PPasse Masc Pl Def AVoc)) ++
+           tr (th "PPasse Fem Sg Indef ANomAcc" ++ td (x.s ! PPasse Fem Sg Indef ANomAcc)) ++
+           tr (th "PPasse Fem Sg Indef AGenDat" ++ td (x.s ! PPasse Fem Sg Indef AGenDat)) ++
+           tr (th "PPasse Fem Sg Indef AVoc" ++ td (x.s ! PPasse Fem Sg Indef AVoc)) ++
+           tr (th "PPasse Fem Sg Def ANomAcc" ++ td (x.s ! PPasse Fem Sg Def ANomAcc)) ++
+           tr (th "PPasse Fem Sg Def AGenDat" ++ td (x.s ! PPasse Fem Sg Def AGenDat)) ++
+           tr (th "PPasse Fem Sg Def AVoc" ++ td (x.s ! PPasse Fem Sg Def AVoc)) ++
+           tr (th "PPasse Fem Pl Indef ANomAcc" ++ td (x.s ! PPasse Fem Pl Indef ANomAcc)) ++
+           tr (th "PPasse Fem Pl Indef AGenDat" ++ td (x.s ! PPasse Fem Pl Indef AGenDat)) ++
+           tr (th "PPasse Fem Pl Indef AVoc" ++ td (x.s ! PPasse Fem Pl Indef AVoc)) ++
+           tr (th "PPasse Fem Pl Def ANomAcc" ++ td (x.s ! PPasse Fem Pl Def ANomAcc)) ++
+           tr (th "PPasse Fem Pl Def AGenDat" ++ td (x.s ! PPasse Fem Pl Def AGenDat)) ++
+           tr (th "PPasse Fem Pl Def AVoc" ++ td (x.s ! PPasse Fem Pl Def AVoc)) ++
+           tr (intagAttr "th" "rowspan=\"48\"" "isRefl" ++ intagAttr "th" "rowspan=\"4\"" "{g=Masc; n=Sg; p=P1}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P1}).s ! Normal)) ++
+           tr (th "Composite" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P1}).s ! Composite)) ++
+           tr (th "Short" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P1}).s ! Short)) ++
+           tr (th "Imperative" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P1}).s ! Imperative)) ++
+           tr (intagAttr "th" "rowspan=\"4\"" "{g=Masc; n=Sg; p=P2}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P2}).s ! Normal)) ++
+           tr (th "Composite" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P2}).s ! Composite)) ++
+           tr (th "Short" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P2}).s ! Short)) ++
+           tr (th "Imperative" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P2}).s ! Imperative)) ++
+           tr (intagAttr "th" "rowspan=\"4\"" "{g=Masc; n=Sg; p=P3}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P3}).s ! Normal)) ++
+           tr (th "Composite" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P3}).s ! Composite)) ++
+           tr (th "Short" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P3}).s ! Short)) ++
+           tr (th "Imperative" ++ td ((x.isRefl ! {g=Masc; n=Sg; p=P3}).s ! Imperative)) ++
+           tr (intagAttr "th" "rowspan=\"4\"" "{g=Masc; n=Pl; p=P1}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P1}).s ! Normal)) ++
+           tr (th "Composite" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P1}).s ! Composite)) ++
+           tr (th "Short" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P1}).s ! Short)) ++
+           tr (th "Imperative" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P1}).s ! Imperative)) ++
+           tr (intagAttr "th" "rowspan=\"4\"" "{g=Masc; n=Pl; p=P2}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P2}).s ! Normal)) ++
+           tr (th "Composite" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P2}).s ! Composite)) ++
+           tr (th "Short" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P2}).s ! Short)) ++
+           tr (th "Imperative" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P2}).s ! Imperative)) ++
+           tr (intagAttr "th" "rowspan=\"4\"" "{g=Masc; n=Pl; p=P3}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P3}).s ! Normal)) ++
+           tr (th "Composite" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P3}).s ! Composite)) ++
+           tr (th "Short" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P3}).s ! Short)) ++
+           tr (th "Imperative" ++ td ((x.isRefl ! {g=Masc; n=Pl; p=P3}).s ! Imperative)) ++
+           tr (intagAttr "th" "rowspan=\"4\"" "{g=Fem; n=Sg; p=P1}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P1}).s ! Normal)) ++
+           tr (th "Composite" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P1}).s ! Composite)) ++
+           tr (th "Short" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P1}).s ! Short)) ++
+           tr (th "Imperative" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P1}).s ! Imperative)) ++
+           tr (intagAttr "th" "rowspan=\"4\"" "{g=Fem; n=Sg; p=P2}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P2}).s ! Normal)) ++
+           tr (th "Composite" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P2}).s ! Composite)) ++
+           tr (th "Short" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P2}).s ! Short)) ++
+           tr (th "Imperative" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P2}).s ! Imperative)) ++
+           tr (intagAttr "th" "rowspan=\"4\"" "{g=Fem; n=Sg; p=P3}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P3}).s ! Normal)) ++
+           tr (th "Composite" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P3}).s ! Composite)) ++
+           tr (th "Short" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P3}).s ! Short)) ++
+           tr (th "Imperative" ++ td ((x.isRefl ! {g=Fem; n=Sg; p=P3}).s ! Imperative)) ++
+           tr (intagAttr "th" "rowspan=\"4\"" "{g=Fem; n=Pl; p=P1}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P1}).s ! Normal)) ++
+           tr (th "Composite" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P1}).s ! Composite)) ++
+           tr (th "Short" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P1}).s ! Short)) ++
+           tr (th "Imperative" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P1}).s ! Imperative)) ++
+           tr (intagAttr "th" "rowspan=\"4\"" "{g=Fem; n=Pl; p=P2}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P2}).s ! Normal)) ++
+           tr (th "Composite" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P2}).s ! Composite)) ++
+           tr (th "Short" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P2}).s ! Short)) ++
+           tr (th "Imperative" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P2}).s ! Imperative)) ++
+           tr (intagAttr "th" "rowspan=\"4\"" "{g=Fem; n=Pl; p=P3}" ++ intagAttr "th" "rowspan=\"4\"" "s" ++ th "Normal" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P3}).s ! Normal)) ++
+           tr (th "Composite" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P3}).s ! Composite)) ++
+           tr (th "Short" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P3}).s ! Short)) ++
+           tr (th "Imperative" ++ td ((x.isRefl ! {g=Fem; n=Pl; p=P3}).s ! Imperative))) ;
+
+lin
+  NoDefinition   t     = {s=t.s};
+  MkDefinition   t d   = {s="<p><b>Definition:</b>"++t.s++d.s++"</p>"};
+  MkDefinitionEx t d e = {s="<p><b>Definition:</b>"++t.s++d.s++"</p><p><b>Example:</b>"++e.s++"</p>"};lin  MkDocument d i e = {s = i.s1 ++ d.s ++ i.s2 ++ i.s3 ++ e.s} ;  MkTag i = {s = i.t} ;
+}

--- a/src/romanian/LangRon.gf
+++ b/src/romanian/LangRon.gf
@@ -4,6 +4,7 @@
 concrete LangRon of Lang = 
   GrammarRon,
   LexiconRon
+  , DocumentationRon --# notpresent
   ** {
 
 flags startcat = Phr ; unlexer = text ; lexer = text ;


### PR DESCRIPTION
With these, I am able to do make install in gf-rgl, and that will create `SyntaxBen.gfo` and  `SymbolicBen.gfo` into my GF_LIB_PATH/alltenses..

And then in gf-wikidata-tools, I am missing a mkPrep instance that works. If you want to make HumanDescriptionsBen working, replace line 39 with this:

```haskell
  Bornin country = SyntaxBen.mkAdv in_Prep country.s ;
``` 

Let me know if you still don't get HumanDescriptionsBen working after that.